### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,5 +44,5 @@ Suggests:
     tidyverse,
     tidytext
 VignetteBuilder: knitr
-URL: https://github.com/s87jackson/rfars
+URL: https://s87jackson.github.io/rfars/, https://github.com/s87jackson/rfars
 BugReports: https://github.com/s87jackson/rfars/issues


### PR DESCRIPTION
for discoverability https://blog.r-hub.io/2019/12/10/urls/

You may consider adding it in the About section) of the gh homepage (top-right corner)