### PR TITLE
Harmonize spelling and sorting of source data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rfars
 Type: Package
 Title: Download and Analyze Crash Data
-Version: 1.1.0
+Version: 1.2.0
 Authors@R: person("Steve", "Jackson", 
     email="steve.jackson@toxcel.com",
     role = c("aut", "cre"),

--- a/R/use_fars.R
+++ b/R/use_fars.R
@@ -8,6 +8,11 @@
 #'
 #' @return Returns an object of class 'FARS' which is a list of six tibbles:
 #'     flat, multi_acc, multi_veh, multi_per, events, and codebook.
+#'
+#' @details The `inj_sev` data through 2016 contains the typo `Injury(…)` (no whitespace),
+#'     while data from 2017 onwards contains `Injury (…)` (correct space).
+#'     Also, the order of months is alphabetical rather than chronological.
+#'     Both these inconsistencies are cleaned up automatically.
 
 use_fars <- function(dir, prepared_dir, cache){
 
@@ -27,7 +32,11 @@ use_fars <- function(dir, prepared_dir, cache){
           }) %>%
         bind_rows() %>%
         readr::type_convert() %>%
-        distinct()
+        distinct() %>%
+        mutate(
+          month = factor(month, levels = month.name, ordered = TRUE),
+          inj_sev = gsub('Injury(', 'Injury (', inj_sev, fixed = TRUE)
+        )
 
       })
 

--- a/man/use_fars.Rd
+++ b/man/use_fars.Rd
@@ -20,3 +20,9 @@ Returns an object of class 'FARS' which is a list of six tibbles:
 \description{
 Compile multiple years of prepared FARS data.
 }
+\details{
+The `inj_sev` data through 2016 contains the typo `Injury(…)` (no whitespace),
+    while data from 2017 onwards contains `Injury (…)` (correct space).
+    Also, the order of months is alphabetical rather than chronological.
+    Both these inconsistencies are cleaned up automatically.
+}


### PR DESCRIPTION
Thank you for this pkg, @s87jackson :-)

I wondered whether _some_ automated cleanup of [codebook inconsistencies](https://s87jackson.github.io/rfars/articles/Searchable_Codebooks.html) would be sensible? Presumably, no user wants to have _slightly_ diverging category labels or unordered months?

This MR hard-codes such cleanups to the effect of for example:

| CRAN release 1.1.0 | this MR |
| - | - |
| <img width="687" alt="Screenshot 2024-02-19 at 20 17 35" src="https://github.com/s87jackson/rfars/assets/9948149/fa5989c7-3157-41f7-a15a-c1232a3f9f20"> | <img width="699" alt="Screenshot 2024-02-19 at 20 29 24" src="https://github.com/s87jackson/rfars/assets/9948149/d0546ed3-f1d0-4091-bd23-a7241210153a"> |

### Possible alternatives

1. (a) parameter(s) in front of any cleanup
1. dedicated helper functions
1. only a vignette with examples
1. Asking FARS authors whether this can be cleaned up in source data?
